### PR TITLE
Remove floorId from floorStatus message

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -479,13 +479,12 @@ class User {
 
   /**
    * Sends a floor status message to the BFCP endpoint.
-   * @param  {Integer} floorId The floor id
    * @param  {Boolean} status  The floor status value. Can be true
    * representing Granted, or false, representing Released.
    * @public
    */
-  floorStatus(floorId, status) {
-    this._sendFloorStatus(floorId, status);
+  floorStatus(status) {
+    this._sendFloorStatus(this.wantedFloorId, status);
   }
 
   /**


### PR DESCRIPTION
This information is already stored in User class, there's no need to pass it in the floorStatus function