### PR TITLE
Use remote port from server's perspective, instead negotiated port

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -345,6 +345,7 @@ class User extends EventEmitter {
     });
 
     this.bfcpConnection.on('message', (msg, rinfo) => {
+      this._port = rinfo.port;
       this._receiveMessage(msg);
     });
   }


### PR DESCRIPTION
When behind NAT, endpoints may user a different port (instead of negotiated one)